### PR TITLE
feat: unify form inputs with reusable component

### DIFF
--- a/src/components/FloatInput.jsx
+++ b/src/components/FloatInput.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+export default function FloatInput({
+  id,
+  label,
+  type = "text",
+  value,
+  onChange,
+  required,
+  placeholder = " ",
+  autoComplete = "off",
+  className = "",
+}) {
+  return (
+    <label htmlFor={id} className={`relative block ${className}`}>
+      <input
+        id={id}
+        type={type}
+        value={value}
+        onChange={onChange}
+        required={required}
+        placeholder={placeholder}
+        autoComplete={autoComplete}
+        className="peer w-full rounded border border-gray-300 px-3 pt-5 pb-2 shadow-sm focus:border-blue-600 focus:outline-none sm:text-sm"
+      />
+      <span className="pointer-events-none absolute left-3 top-1 text-sm text-gray-700 transition-all duration-200 peer-placeholder-shown:top-3.5 peer-placeholder-shown:text-base peer-focus:top-2 peer-focus:text-sm px-1">
+        {label}
+      </span>
+    </label>
+  );
+}

--- a/src/pages/eventos/CrearEvento.jsx
+++ b/src/pages/eventos/CrearEvento.jsx
@@ -1,25 +1,8 @@
 import React, { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import api from "../../services/axios";
+import FloatInput from "../../components/FloatInput";
 
-/** Input con label flotante (mismo estilo que login/registro) */
-const FloatInput = ({ id, type="text", value, onChange, label, required, placeholder=" " }) => (
-  <label htmlFor={id} className="relative block">
-    <input
-      id={id}
-      type={type}
-      value={value}
-      onChange={onChange}
-      required={required}
-      placeholder={placeholder}
-      autoComplete="off"
-      className="peer w-full rounded border border-gray-300 px-3 pt-5 pb-2 shadow-sm focus:border-blue-600 focus:outline-none sm:text-sm"
-    />
-    <span className="pointer-events-none absolute left-3 top-1 text-sm text-gray-700 transition-all duration-200 peer-placeholder-shown:top-3.5 peer-placeholder-shown:text-base peer-focus:top-2 peer-focus:text-sm px-1">
-      {label}
-    </span>
-  </label>
-);
 
 export default function CrearEvento() {
   const navigate = useNavigate();

--- a/src/pages/invitaciones/Invitar.jsx
+++ b/src/pages/invitaciones/Invitar.jsx
@@ -1,41 +1,26 @@
-// src/pages/invitaciones/Invitar.jsx
 import React, { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import api from "../../services/axios";
+import FloatInput from "../../components/FloatInput";
 
 const Row = ({ i, value, onChange, onRemove }) => (
   <div className="grid grid-cols-1 gap-3 md:grid-cols-5">
-    {/* Nombre (solo UI, hoy no se envía al backend) */}
-    <label className="relative block md:col-span-2">
-      <input
-        type="text"
-        value={value.nombre || ""}
-        onChange={(e) => onChange(i, { ...value, nombre: e.target.value })}
-        className="peer w-full rounded border border-gray-300 px-3 pt-5 pb-2 shadow-sm focus:border-blue-600 focus:outline-none sm:text-sm"
-        placeholder=" "
-        autoComplete="off"
-      />
-      <span className="pointer-events-none absolute left-3 top-1 text-sm text-gray-700 transition-all duration-200 peer-placeholder-shown:top-3.5 peer-placeholder-shown:text-base peer-focus:top-2 peer-focus:text-sm px-1">
-        Nombre (opcional)
-      </span>
-    </label>
-
-    {/* Email (requerido y lo que realmente envía el backend) */}
-    <label className="relative block md:col-span-3">
-      <input
-        type="email"
-        value={value.email}
-        onChange={(e) => onChange(i, { ...value, email: e.target.value })}
-        required
-        className="peer w-full rounded border border-gray-300 px-3 pt-5 pb-2 shadow-sm focus:border-blue-600 focus:outline-none sm:text-sm"
-        placeholder=" "
-        autoComplete="off"
-      />
-      <span className="pointer-events-none absolute left-3 top-1 text-sm text-gray-700 transition-all duration-200 peer-placeholder-shown:top-3.5 peer-placeholder-shown:text-base peer-focus:top-2 peer-focus:text-sm px-1">
-        Email
-      </span>
-    </label>
-
+    <FloatInput
+      id={`nombre-${i}`}
+      value={value.nombre || ""}
+      onChange={(e) => onChange(i, { ...value, nombre: e.target.value })}
+      label="Nombre (opcional)"
+      className="md:col-span-2"
+    />
+    <FloatInput
+      id={`email-${i}`}
+      type="email"
+      value={value.email}
+      onChange={(e) => onChange(i, { ...value, email: e.target.value })}
+      label="Email"
+      required
+      className="md:col-span-3"
+    />
     <button
       type="button"
       onClick={() => onRemove(i)}

--- a/src/pages/login/Login.jsx
+++ b/src/pages/login/Login.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import api from "../../services/axios";
 import { useNavigate } from "react-router-dom";
+import FloatInput from "../../components/FloatInput";
 
 export default function Login() {
   const [email, setEmail] = useState("");
@@ -28,47 +29,30 @@ export default function Login() {
           Iniciar sesión
         </h2>
         <form className="space-y-6" onSubmit={handleSubmit}>
-          {/* Mostrar error */}
           {error && (
             <div className="bg-red-100 text-red-700 px-4 py-2 rounded text-center mb-2">
               {error}
             </div>
           )}
-          {/* Email */}
-          <label htmlFor="email" className="relative block">
-            <input
-              type="email"
-              id="email"
-              value={email}
-              onChange={e => setEmail(e.target.value)}
-              required
-              className="peer w-full rounded border border-gray-300 px-3 pt-5 pb-2 shadow-sm focus:border-blue-600 focus:outline-none sm:text-sm"
-              placeholder=" "
-              autoComplete="off"
-            />
-            <span className="pointer-events-none absolute left-3 text-sm text-gray-700 transition-all duration-200 peer-placeholder-shown:top-3.5 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:text-sm px-1">
-              Email
-            </span>
-          </label>
-          {/* Password */}
-          <label htmlFor="password" className="relative block">
-            <input
-              type="password"
-              id="password"
-              value={password}
-              onChange={e => setPassword(e.target.value)}
-              required
-              className="peer w-full rounded border border-gray-300 px-3 pt-5 pb-2 shadow-sm focus:border-blue-600 focus:outline-none sm:text-sm "
-              placeholder=" "
-              autoComplete="off"
-            />
-            <span className="pointer-events-none absolute left-3 text-sm text-gray-700 transition-all duration-200 peer-placeholder-shown:top-3.5 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:text-sm  px-1 ">
-              Contraseña
-            </span>
-          </label>
+          <FloatInput
+            id="email"
+            type="email"
+            label="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+          <FloatInput
+            id="password"
+            type="password"
+            label="Contraseña"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
           <button
             type="submit"
-            className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700 transition font-semibold  cursor-pointer"
+            className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700 transition font-semibold cursor-pointer"
           >
             Iniciar sesión
           </button>

--- a/src/pages/registro/Registro.jsx
+++ b/src/pages/registro/Registro.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import api from "../../services/axios";
 import { useNavigate } from "react-router-dom";
+import FloatInput from "../../components/FloatInput";
 
 export default function Registro() {
   const [nombre, setNombre] = useState("");
@@ -33,7 +34,6 @@ export default function Registro() {
           Registro
         </h2>
         <form className="space-y-6" onSubmit={handleSubmit}>
-          {/* Mostrar mensajes */}
           {error && (
             <div className="bg-red-100 text-red-700 px-4 py-2 rounded text-center mb-2">
               {error}
@@ -44,57 +44,32 @@ export default function Registro() {
               {exito}
             </div>
           )}
-          {/* Nombre */}
-          <label htmlFor="nombre" className="relative block">
-            <input
-              type="text"
-              id="nombre"
-              value={nombre}
-              onChange={e => setNombre(e.target.value)}
-              required
-              className="peer w-full rounded border border-gray-300 px-3 pt-5 pb-2 shadow-sm focus:border-blue-600 focus:outline-none sm:text-sm"
-              placeholder=" "
-              autoComplete="off"
-            />
-            <span className="pointer-events-none absolute left-3 text-sm text-gray-700 transition-all duration-200 peer-placeholder-shown:top-3.5 peer-placeholder-shown:text-base peer-focus:top-2 peer-focus:text-sm px-1">
-              Nombre
-            </span>
-          </label>
-          {/* Email */}
-          <label htmlFor="email" className="relative block">
-            <input
-              type="email"
-              id="email"
-              value={email}
-              onChange={e => setEmail(e.target.value)}
-              required
-              className="peer w-full rounded border border-gray-300 px-3 pt-5 pb-2 shadow-sm focus:border-blue-600 focus:outline-none sm:text-sm"
-              placeholder=" "
-              autoComplete="off"
-            />
-            <span className="pointer-events-none absolute left-3 text-sm text-gray-700 transition-all duration-200 peer-placeholder-shown:top-3.5 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:text-sm px-1">
-              Email
-            </span>
-          </label>
-          {/* Password */}
-          <label htmlFor="password" className="relative block">
-            <input
-              type="password"
-              id="password"
-              value={password}
-              onChange={e => setPassword(e.target.value)}
-              required
-              className="peer w-full rounded border border-gray-300 px-3 pt-5 pb-2 shadow-sm focus:border-blue-600 focus:outline-none sm:text-sm"
-              placeholder=" "
-              autoComplete="off"
-            />
-            <span className="pointer-events-none absolute left-3 text-sm text-gray-700 transition-all duration-200 peer-placeholder-shown:top-3.5 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:text-sm px-1">
-              Contraseña
-            </span>
-          </label>
+          <FloatInput
+            id="nombre"
+            label="Nombre"
+            value={nombre}
+            onChange={(e) => setNombre(e.target.value)}
+            required
+          />
+          <FloatInput
+            id="email"
+            type="email"
+            label="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+          <FloatInput
+            id="password"
+            type="password"
+            label="Contraseña"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
           <button
             type="submit"
-            className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700 transition font-semibold  cursor-pointer"
+            className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700 transition font-semibold cursor-pointer"
           >
             Registrar
           </button>


### PR DESCRIPTION
## Summary
- add reusable `FloatInput` component with floating labels
- refactor login, registration, event creation and invitations pages to use shared input styling

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689980298f14833390b392493b8272dc