### PR TITLE
fix: hide invitation link when token missing

### DIFF
--- a/src/pages/dashboard/Dashboard.jsx
+++ b/src/pages/dashboard/Dashboard.jsx
@@ -33,13 +33,17 @@ const InviteRow = ({ invite }) => (
       <StatusPill value={invite.estado} />
     </td>
     <td className="py-3 text-right">
-      <a
-        href={invite.token ? `${window.location.origin}/invitaciones/responder/${invite.token}` : "#"}
-        className="text-sm text-blue-600 hover:underline"
-        target="_blank" rel="noreferrer"
-      >
-        Ver enlace
-      </a>
+      {invite.token ? (
+        <a
+          href={`${window.location.origin}/invitaciones/responder/${invite.token}`}
+          className="text-sm text-blue-600 hover:underline"
+          target="_blank" rel="noreferrer"
+        >
+          Ver enlace
+        </a>
+      ) : (
+        <span className="text-sm text-gray-400">Sin enlace</span>
+      )}
     </td>
   </tr>
 );


### PR DESCRIPTION
## Summary
- render invitation link only when a token exists

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ac22986288333b90c5653efdba3c7