### PR TITLE
feat: add Nimbus Assistant with AI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,45 @@ npm run build
 
 Las peticiones al backend se realizan contra `http://localhost:5000/api`,
 configurable en [`src/services/axios.js`](src/services/axios.js).
+
+## Nimbus Assistant
+
+Se añadió un asistente de IA lateral llamado **Nimbus Assistant**. El backend
+expone los endpoints:
+
+- `POST /api/ai/chat`: chat contextual con herramientas.
+- `POST /api/ai/embed`: inserta embeddings (admin).
+
+### Variables de entorno
+
+Crear un archivo `.env` en la raíz del backend con:
+
+```
+OPENAI_API_KEY=...
+LLM_PROVIDER=openai
+GOOGLE_PLACES_API_KEY=...
+JWT_SECRET=...
+MONGODB_URI=...
+```
+
+### Ejecutar backend
+
+```bash
+cd backend
+npm install
+npm start
+```
+
+### Tests
+
+```bash
+cd backend
+npm test
+```
+
+## Ejemplos de prompts
+
+- `/email` Redactar mail cordial para cliente ACME.
+- `/margen` Calcular margen de producto con costo 50 y precio 100.
+- `/presupuesto` Crear presupuesto para cliente 123.
+- `/buscar` Proveedores de catering cerca de Rosario.

--- a/backend/controllers/aiController.js
+++ b/backend/controllers/aiController.js
@@ -1,0 +1,45 @@
+import llmClient from '../services/ai/llmClient.js';
+import rag from '../services/ai/rag/ragClient.js';
+
+const SYSTEM_PROMPT = 'Sos Nimbus Assistant. Respondé breve y accionable. Usá herramientas cuando corresponda. Nunca expongas secretos. Siempre respetá empresaId.';
+
+export async function chat(req, res) {
+  try {
+    const { messages = [], toolsAllowed = [] } = req.body;
+    const empresaId = req.empresaId;
+    const lastUser = messages.filter((m) => m.role === 'user').slice(-1)[0];
+    let contextDocs = [];
+    try {
+      contextDocs = await rag.search(empresaId, lastUser?.content || '', 4);
+    } catch (e) {
+      console.warn('RAG search failed', e);
+    }
+    const contextBlock = contextDocs.map((d) => d.text).join('\n');
+    const msgs = [
+      { role: 'system', content: SYSTEM_PROMPT + (contextBlock ? `\n\nContexto:\n${contextBlock}` : '') },
+      ...messages,
+    ];
+    const result = await llmClient.chatWithTools({ messages: msgs, tools: toolsAllowed, empresaId });
+    res.json(result);
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: 'AI_ERROR' });
+  }
+}
+
+export async function embed(req, res) {
+  if (req.user?.role !== 'admin') {
+    return res.status(403).json({ error: 'forbidden' });
+  }
+  try {
+    const { docs = [] } = req.body;
+    const empresaId = req.empresaId;
+    await rag.upsertDocs(empresaId, docs);
+    res.json({ inserted: docs.length });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: 'EMBED_ERROR' });
+  }
+}
+
+export default { chat, embed };

--- a/backend/middleware/rateLimitAi.js
+++ b/backend/middleware/rateLimitAi.js
@@ -1,0 +1,16 @@
+import rateLimit from 'express-rate-limit';
+
+export const limitByIp = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 20,
+  message: 'Too many requests from this IP',
+});
+
+export const limitByTenant = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 60,
+  keyGenerator: (req) => req.empresaId || req.ip,
+  message: 'Too many requests for this tenant',
+});
+
+export default { limitByIp, limitByTenant };

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "crm-backend",
+  "type": "module",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node --test services/ai/tools/tool.calculateMargins.test.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "express-rate-limit": "^6.7.0",
+    "morgan": "^1.10.0",
+    "node-fetch": "^3.3.2",
+    "openai": "^4.0.0",
+    "mongodb": "^5.7.0"
+  }
+}

--- a/backend/routes/aiRoutes.js
+++ b/backend/routes/aiRoutes.js
@@ -1,0 +1,22 @@
+import express from 'express';
+import { chat, embed } from '../controllers/aiController.js';
+import { body, validationResult } from 'express-validator';
+
+const router = express.Router();
+
+router.post(
+  '/chat',
+  body('messages').isArray(),
+  (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    next();
+  },
+  chat
+);
+
+router.post('/embed', embed);
+
+export default router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,21 @@
+/* eslint-env node */
+/* global process */
+import express from 'express';
+import cors from 'cors';
+import morgan from 'morgan';
+import aiRoutes from './routes/aiRoutes.js';
+import { limitByIp, limitByTenant } from './middleware/rateLimitAi.js';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+app.use(morgan('dev'));
+
+// In a real app, middleware to set req.empresaId and roles would go here
+
+app.use('/api/ai', limitByIp, limitByTenant, aiRoutes);
+
+const PORT = process.env.PORT || 5000;
+app.listen(PORT, () => console.log(`AI server running on port ${PORT}`));
+
+export default app;

--- a/backend/services/ai/llmClient.js
+++ b/backend/services/ai/llmClient.js
@@ -1,0 +1,57 @@
+/* eslint-env node */
+/* global process */
+import OpenAI from 'openai';
+import generateEmail from './tools/tool.generateEmail.js';
+import calculateMargins from './tools/tool.calculateMargins.js';
+import createQuote from './tools/tool.createQuote.js';
+import searchNearby from './tools/tool.searchNearby.js';
+import summarizeRecords from './tools/tool.summarizeRecords.js';
+
+const TOOL_MAP = {
+  generateEmail,
+  calculateMargins,
+  createQuote,
+  searchNearby,
+  summarizeRecords,
+};
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+export async function chatWithTools({ messages, tools = [], systemPrompt, temperature = 0.2, empresaId }) {
+  const selected = tools.length ? tools.filter((t) => TOOL_MAP[t]).map((t) => TOOL_MAP[t]) : Object.values(TOOL_MAP);
+  const toolDefs = selected.map((t) => ({ type: 'function', function: t.schema }));
+  const msgs = systemPrompt ? [{ role: 'system', content: systemPrompt }, ...messages] : messages;
+
+  let response = await client.chat.completions.create({
+    model: process.env.LLM_MODEL || 'gpt-4o-mini',
+    messages: msgs,
+    temperature,
+    tools: toolDefs,
+  });
+
+  const assistantMsg = response.choices[0].message;
+
+  if (assistantMsg.tool_calls?.length) {
+    const call = assistantMsg.tool_calls[0];
+    const tool = selected.find((t) => t.schema.name === call.function.name);
+    if (tool) {
+      const args = JSON.parse(call.function.arguments || '{}');
+      const result = await tool.run({ ...args, empresaId });
+      msgs.push(assistantMsg);
+      msgs.push({ role: 'tool', name: call.function.name, content: JSON.stringify(result) });
+      const follow = await client.chat.completions.create({
+        model: process.env.LLM_MODEL || 'gpt-4o-mini',
+        messages: msgs,
+        temperature,
+      });
+      return {
+        messages: [...msgs, follow.choices[0].message],
+        toolCalls: [{ name: call.function.name, args, result }],
+      };
+    }
+  }
+
+  return { messages: [...msgs, assistantMsg] };
+}
+
+export default { chatWithTools };

--- a/backend/services/ai/rag/embedder.js
+++ b/backend/services/ai/rag/embedder.js
@@ -1,0 +1,15 @@
+/* eslint-env node */
+/* global process */
+import OpenAI from 'openai';
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+export async function embed(text) {
+  const res = await client.embeddings.create({
+    model: 'text-embedding-3-small',
+    input: text,
+  });
+  return res.data[0].embedding;
+}
+
+export default { embed };

--- a/backend/services/ai/rag/ragClient.js
+++ b/backend/services/ai/rag/ragClient.js
@@ -1,0 +1,41 @@
+/* eslint-env node */
+/* global process */
+import { MongoClient } from 'mongodb';
+import { embed } from './embedder.js';
+
+const client = new MongoClient(process.env.MONGODB_URI);
+const COLLECTION = 'tenant_docs';
+
+export async function upsertDocs(empresaId, docs = []) {
+  await client.connect();
+  const col = client.db().collection(COLLECTION);
+  const ops = await Promise.all(
+    docs.map(async (d) => ({
+      updateOne: {
+        filter: { empresaId, id: d.id },
+        update: { $set: { ...d, empresaId, embedding: await embed(d.text) } },
+        upsert: true,
+      },
+    }))
+  );
+  if (ops.length) await col.bulkWrite(ops);
+}
+
+function cosine(a, b) {
+  const dot = a.reduce((s, x, i) => s + x * b[i], 0);
+  const na = Math.sqrt(a.reduce((s, x) => s + x * x, 0));
+  const nb = Math.sqrt(b.reduce((s, x) => s + x * x, 0));
+  return dot / (na * nb);
+}
+
+export async function search(empresaId, query, k = 3) {
+  await client.connect();
+  const col = client.db().collection(COLLECTION);
+  const qEmb = await embed(query);
+  const all = await col.find({ empresaId }).toArray();
+  const scored = all.map((d) => ({ ...d, score: cosine(qEmb, d.embedding) }));
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, k).map((d) => ({ id: d.id, text: d.text, score: d.score }));
+}
+
+export default { upsertDocs, search };

--- a/backend/services/ai/tools/tool.calculateMargins.js
+++ b/backend/services/ai/tools/tool.calculateMargins.js
@@ -1,0 +1,24 @@
+export const schema = {
+  name: 'calculateMargins',
+  description: 'Calcula márgenes a partir de costo y precio.',
+  parameters: {
+    type: 'object',
+    properties: {
+      cost: { type: 'number' },
+      price: { type: 'number' },
+      taxesPct: { type: 'number', default: 0 },
+      feesPct: { type: 'number', default: 0 },
+    },
+    required: ['cost', 'price'],
+  },
+};
+
+export async function run({ cost, price, taxesPct = 0, feesPct = 0 }) {
+  const taxes = (price * taxesPct) / 100;
+  const fees = (price * feesPct) / 100;
+  const marginAbs = price - cost - taxes - fees;
+  const marginPct = (marginAbs / price) * 100;
+  return { marginAbs, marginPct, breakdown: { cost, price, taxes, fees } };
+}
+
+export default { schema, run };

--- a/backend/services/ai/tools/tool.calculateMargins.test.js
+++ b/backend/services/ai/tools/tool.calculateMargins.test.js
@@ -1,0 +1,9 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { run } from './tool.calculateMargins.js';
+
+test('calculateMargins basic', async () => {
+  const res = await run({ cost: 50, price: 100 });
+  assert.equal(res.marginAbs, 50);
+  assert.ok(Math.abs(res.marginPct - 50) < 1e-6);
+});

--- a/backend/services/ai/tools/tool.createQuote.js
+++ b/backend/services/ai/tools/tool.createQuote.js
@@ -1,0 +1,34 @@
+/* eslint-env node */
+export const schema = {
+  name: 'createQuote',
+  description: 'Crea un presupuesto en la base de datos.',
+  parameters: {
+    type: 'object',
+    properties: {
+      clienteId: { type: 'string' },
+      items: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            productoId: { type: 'string' },
+            qty: { type: 'number' },
+            price: { type: 'number' },
+          },
+          required: ['productoId', 'qty', 'price'],
+        },
+      },
+      notas: { type: 'string' },
+    },
+    required: ['clienteId', 'items'],
+  },
+};
+
+export async function run({ clienteId, items, notas = '' }) {
+  const total = items.reduce((sum, it) => sum + it.qty * it.price, 0);
+  const presupuestoId = `pres-${Date.now()}`;
+  // Aquí se insertaría en MongoDB
+  return { presupuestoId, total, clienteId, notas };
+}
+
+export default { schema, run };

--- a/backend/services/ai/tools/tool.generateEmail.js
+++ b/backend/services/ai/tools/tool.generateEmail.js
@@ -1,0 +1,23 @@
+export const schema = {
+  name: 'generateEmail',
+  description: 'Redacta un email breve para clientes o presupuestos.',
+  parameters: {
+    type: 'object',
+    properties: {
+      toName: { type: 'string' },
+      tone: { type: 'string', enum: ['cordial', 'formal', 'persuasivo'], default: 'cordial' },
+      topic: { type: 'string' },
+      context: { type: 'string' },
+    },
+    required: ['topic'],
+  },
+};
+
+export async function run({ toName = '', tone = 'cordial', topic, context = '' }) {
+  const greeting = toName ? `Hola ${toName},` : 'Hola,';
+  const toneSign = { cordial: 'Saludos cordiales', formal: 'Atentamente', persuasivo: 'Quedo a disposición' }[tone] || 'Saludos';
+  const body = `${greeting}\n\n${context}\n\n${topic}.\n\n${toneSign}.`;
+  return { subject: `Sobre ${topic}`, body };
+}
+
+export default { schema, run };

--- a/backend/services/ai/tools/tool.searchNearby.js
+++ b/backend/services/ai/tools/tool.searchNearby.js
@@ -1,0 +1,36 @@
+/* eslint-env node */
+/* global process */
+import fetch from 'node-fetch';
+
+export const schema = {
+  name: 'searchNearby',
+  description: 'Busca negocios cercanos usando Google Places API.',
+  parameters: {
+    type: 'object',
+    properties: {
+      query: { type: 'string' },
+      lat: { type: 'number' },
+      lng: { type: 'number' },
+      radius: { type: 'number' },
+    },
+    required: ['query'],
+  },
+};
+
+export async function run({ query, lat = -34.6037, lng = -58.3816, radius = 1500 }) {
+  const key = process.env.GOOGLE_PLACES_API_KEY;
+  const url = `https://maps.googleapis.com/maps/api/place/textsearch/json?query=${encodeURIComponent(
+    query
+  )}&location=${lat},${lng}&radius=${radius}&key=${key}`;
+  const res = await fetch(url);
+  const data = await res.json();
+  return (data.results || []).slice(0, 5).map((r) => ({
+    name: r.name,
+    address: r.formatted_address,
+    rating: r.rating,
+    placeId: r.place_id,
+    mapUrl: `https://maps.google.com/?q=${encodeURIComponent(r.name)}&ll=${r.geometry.location.lat},${r.geometry.location.lng}`,
+  }));
+}
+
+export default { schema, run };

--- a/backend/services/ai/tools/tool.summarizeRecords.js
+++ b/backend/services/ai/tools/tool.summarizeRecords.js
@@ -1,0 +1,19 @@
+export const schema = {
+  name: 'summarizeRecords',
+  description: 'Devuelve un resumen simple de registros del CRM.',
+  parameters: {
+    type: 'object',
+    properties: {
+      entity: { type: 'string', enum: ['clientes', 'ventas', 'productos'] },
+      filters: { type: 'object' },
+    },
+    required: ['entity'],
+  },
+};
+
+export async function run({ entity }) {
+  // Implementación de ejemplo, en real consultaría la DB
+  return { entity, count: 0, top: [] };
+}
+
+export default { schema, run };

--- a/src/components/assistant/AssistantPanel.jsx
+++ b/src/components/assistant/AssistantPanel.jsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import MessageBubble from './MessageBubble.jsx';
+import PromptBox from './PromptBox.jsx';
+import api from '../../services/axios.js';
+
+export default function AssistantPanel() {
+  const [messages, setMessages] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  const sendMessage = async (content) => {
+    const next = [...messages, { role: 'user', content }];
+    setMessages(next);
+    setLoading(true);
+    try {
+      const { data } = await api.post('/ai/chat', { messages: next.slice(-10) });
+      if (Array.isArray(data?.messages)) setMessages(data.messages);
+    } catch (e) {
+      console.error(e);
+    }
+    setLoading(false);
+  };
+
+  return (
+    <aside className="fixed right-0 top-0 z-40 flex h-full w-80 flex-col border-l border-gray-200 bg-white">
+      <div className="flex-1 space-y-2 overflow-y-auto p-4">
+        {messages.map((m, i) => (
+          <MessageBubble key={i} message={m} />
+        ))}
+        {loading && <div className="text-sm text-gray-500">Pensando...</div>}
+      </div>
+      <PromptBox onSend={sendMessage} disabled={loading} />
+    </aside>
+  );
+}

--- a/src/components/assistant/MessageBubble.jsx
+++ b/src/components/assistant/MessageBubble.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function MessageBubble({ message }) {
+  const isUser = message.role === 'user';
+  const bubble = isUser
+    ? 'bg-blue-600 text-white self-end'
+    : 'bg-gray-100 text-gray-800 self-start';
+  return (
+    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>
+      <div className={`max-w-xs rounded-lg px-3 py-2 text-sm ${bubble}`}>{message.content}</div>
+    </div>
+  );
+}

--- a/src/components/assistant/PromptBox.jsx
+++ b/src/components/assistant/PromptBox.jsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+
+export default function PromptBox({ onSend, disabled }) {
+  const [value, setValue] = useState('');
+
+  const submit = (e) => {
+    e.preventDefault();
+    if (!value.trim()) return;
+    onSend(value.trim());
+    setValue('');
+  };
+
+  return (
+    <form onSubmit={submit} className="border-t p-3">
+      <textarea
+        className="h-20 w-full resize-none rounded border px-2 py-1 text-sm"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="Preguntá algo..."
+        disabled={disabled}
+      />
+      <button
+        type="submit"
+        disabled={disabled}
+        className="mt-2 w-full rounded bg-blue-600 py-1 text-sm text-white disabled:opacity-50"
+      >
+        Enviar
+      </button>
+    </form>
+  );
+}

--- a/src/pages/dashboard/Dashboard.jsx
+++ b/src/pages/dashboard/Dashboard.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import api from "../../services/axios";
 import { useNavigate } from "react-router-dom";
+import AssistantPanel from "../../components/assistant/AssistantPanel.jsx";
 
 /** Pills de estado RSVP */
 const StatusPill = ({ value }) => {
@@ -267,6 +268,7 @@ export default function Dashboard() {
           </div>
         )}
       </main>
+      <AssistantPanel />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add Express backend with AI chat endpoint, tool calling and rate limiting
- scaffold RAG utilities and basic AI tools
- add React AssistantPanel for chatting with Nimbus

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd backend && npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c39790a98833381c8588d749e8e3a